### PR TITLE
Merging this change will remove img from the pre-created storage folders, which is not needed by a vanilla Laravel installation

### DIFF
--- a/src/Commands/sailonLagoonAssets/Lagoon/01-entry-point-setup-laravel.sh
+++ b/src/Commands/sailonLagoonAssets/Lagoon/01-entry-point-setup-laravel.sh
@@ -52,13 +52,11 @@ mkdir -p /app/storage/framework/cache/data
 mkdir -p /app/storage/app/public
 mkdir -p /app/storage/logs
 mkdir -p /app/storage/debugbar
-mkdir -p /app/storage/img
 
 fix-permissions /app/storage/framework
 fix-permissions /app/storage/app
 fix-permissions /app/storage/logs
 fix-permissions /app/storage/debugbar
-fix-permissions /app/storage/img
 
 cd /app
 


### PR DESCRIPTION
The img directory came over from a specific Laravel app and isn't needed by Sail:onLagoon in my opinion 