### PR TITLE
Adjustment to where application caches are made in the build process

### DIFF
--- a/src/Commands/sailonLagoonAssets/.lagoon.yml
+++ b/src/Commands/sailonLagoonAssets/.lagoon.yml
@@ -15,19 +15,3 @@ tasks:
         command: php artisan -n migrate --force
         service: cli
         shell: bash
-    - run:
-        name: Clear caches
-        command: php artisan -n cache:clear && php artisan -n route:clear && php artisan -n view:cache
-        service: cli
-        shell: bash
-    - run:
-        name: Build caches when pushing to production
-        when: LAGOON_ENVIRONMENT_TYPE == "production"
-        command: |
-          php artisan config:cache
-          php artisan route:cache
-          php artisan view:cache
-          php artisan event:cache
-          php artisan optimize
-        service: cli
-        shell: bash

--- a/src/Commands/sailonLagoonAssets/Lagoon/cli.dockerfile
+++ b/src/Commands/sailonLagoonAssets/Lagoon/cli.dockerfile
@@ -1,6 +1,8 @@
 FROM uselagoon/lagoon-cli:latest as LAGOONCLI
 FROM uselagoon/php-8.3-cli
 
+ARG LAGOON_ENVIRONMENT_TYPE
+
 #######################################################
 # Install PHP extensions
 #######################################################
@@ -41,6 +43,23 @@ RUN if [ -f "package.json" ]; then \
     npm ci; \
     npm run build; \
   fi
+
+#######################################################
+# Prepare the application
+#######################################################
+
+RUN php artisan config:clear \
+  && php artisan route:clear \
+  && php artisan view:clear \
+  && php artisan event:clear \
+  && php artisan optimize:clear
+
+RUN if [ "$LAGOON_ENVIRONMENT_TYPE" == "production" ]; then php artisan config:cache \
+ && php artisan route:cache \
+ && php artisan view:cache \
+ && php artisan event:cache \
+ && php artisan optimize; \
+ fi
 
 #######################################################
 # Finalize Environment


### PR DESCRIPTION
I dug into Laravel and I had misunderstood what it does actually. These clear and caches don't need access to the DB, Redis, or the running app - so doing them in the cli.dockerfile seems way better.

This probably needs testing though!