### PR TITLE
Adds a service prioritization sort functionality to generating services

### DIFF
--- a/src/Commands/SailonlagoonCommand.php
+++ b/src/Commands/SailonlagoonCommand.php
@@ -248,9 +248,9 @@ class SailonlagoonCommand extends Command
      *
      * @param Collection $order
      * @param Collection $toBeSorted
-     * @return void
+     * @return Collection
      */
-    public static function prioritizeOrder(Collection $order, Collection $toBeSorted): mixed
+    public static function prioritizeOrder(Collection $order, Collection $toBeSorted): Collection
     {
         return $toBeSorted->sortBy(function ($i) use ($order) {
             // all items not in $order will get a large number, all the rest will get the index from $order

--- a/tests/Unit/GenTest.php
+++ b/tests/Unit/GenTest.php
@@ -23,15 +23,13 @@ it('will allow us to remove unused services', function () {
 
 it("should successfully generate a docker-compose.yaml given stubs", function () {
     $sailonLagoonCommand = new SailonlagoonCommand();
-    $serviceList = collect(["cli", "php", "nginx"]);
+    $serviceList = collect(["cli", "mariadb"]);
     $yamlFile = file_get_contents(join_paths(__DIR__, "assets/stubs", "docker-compose.stub"));
     $dockerCompose = $sailonLagoonCommand->generateDockerCompose($serviceList,
         join_paths(__DIR__, "assets/stubs"), $yamlFile);
 
     $yamlOutput = Yaml::dump($dockerCompose, 5);
-    dd($yamlOutput);
     expect($yamlOutput)->toContain("cli")->toContain("mariadb")->not()->toContain("php");
-
 });
 
 it("should order the services in the docker-compose.yaml in the correct order", function () {

--- a/tests/Unit/GenTest.php
+++ b/tests/Unit/GenTest.php
@@ -10,9 +10,9 @@ it('will allow us to remove unused services', function () {
 
     $serviceList = collect(["cli", "php", "mariadb"]);
     $services = [
-      "first" => [
-          "depends_on" => ["cli", "php", "shouldntexist"]
-      ]
+        "first" => [
+            "depends_on" => ["cli", "php", "shouldntexist"]
+        ]
     ];
 
     $newServices = $sailonLagoonCommand->removeUnusedServiceDependencies($services, $serviceList);
@@ -21,14 +21,25 @@ it('will allow us to remove unused services', function () {
     expect($newServices["first"]["depends_on"])->toContain("cli");
 });
 
-it("should successfully generate a docker-compose.yaml given stubs", function() {
+it("should successfully generate a docker-compose.yaml given stubs", function () {
     $sailonLagoonCommand = new SailonlagoonCommand();
-    $serviceList = collect(["cli", "mariadb"]);
+    $serviceList = collect(["cli", "php", "nginx"]);
     $yamlFile = file_get_contents(join_paths(__DIR__, "assets/stubs", "docker-compose.stub"));
     $dockerCompose = $sailonLagoonCommand->generateDockerCompose($serviceList,
         join_paths(__DIR__, "assets/stubs"), $yamlFile);
 
     $yamlOutput = Yaml::dump($dockerCompose, 5);
+    dd($yamlOutput);
     expect($yamlOutput)->toContain("cli")->toContain("mariadb")->not()->toContain("php");
 
+});
+
+it("should order the services in the docker-compose.yaml in the correct order", function () {
+    $sailonLagoonCommand = new SailonlagoonCommand();
+    $serviceList = collect(["php", "cli", "nginx"]);
+    $yamlFile = file_get_contents(join_paths(__DIR__, "assets/stubs", "docker-compose.stub"));
+    $dockerCompose = $sailonLagoonCommand->generateDockerCompose($serviceList,
+        join_paths(__DIR__, "assets/stubs"), $yamlFile);
+
+    expect(array_keys($dockerCompose['services']))->toEqual(['cli', 'nginx', 'php']);
 });

--- a/tests/Unit/OrderTest.php
+++ b/tests/Unit/OrderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+use Uselagoon\Sailonlagoon\Commands\SailonlagoonCommand;
+use function Illuminate\Filesystem\join_paths;
+
+/**
+ * This file contains tests for the static function SailonlagoonCommand:prioritizeOrder
+ */
+
+
+it("should properly sort using prioritizeOrder", function () {
+    $unordered = collect(["z", "f", "a"]);
+    $order = collect(["a"]); //we only worry about if "a" is first
+    /** @var \Ramsey\Collection\Collection $ret */
+    $ret = SailonlagoonCommand::prioritizeOrder($order, $unordered);
+    expect($ret->first())->toEqual("a");
+});
+
+it("should maintain relative order for items not in the order list using prioritizeOrder", function () {
+    $unordered = collect(["z", "f", "a", "c", "b"]);
+    $order = collect(["a", "b", "c"]);
+    /** @var \Illuminate\Support\Collection $ret */
+    $ret = SailonlagoonCommand::prioritizeOrder($order, $unordered);
+
+// Ordered items must be at the beginning and in the correct order
+    expect($ret->slice(0, 3)->values()->all())->toEqual(["a", "b", "c"]);
+
+// Remaining elements should appear in any order but must still be present
+    expect($ret->contains("z"))->toBeTrue();
+    expect($ret->contains("f"))->toBeTrue();
+});
+
+it("should handle an empty toBeSorted collection using prioritizeOrder", function () {
+    $unordered = collect([]);
+    $order = collect(["a", "b", "c"]);
+    /** @var \Illuminate\Support\Collection $ret */
+    $ret = SailonlagoonCommand::prioritizeOrder($order, $unordered);
+
+    expect($ret->isEmpty())->toBeTrue();
+});
+
+it("should handle an empty order collection using prioritizeOrder", function () {
+    $unordered = collect(["x", "y", "z"]);
+    $order = collect([]);
+    /** @var \Illuminate\Support\Collection $ret */
+    $ret = SailonlagoonCommand::prioritizeOrder($order, $unordered);
+
+    expect($ret->all())->toEqual(["x", "y", "z"]); // Should maintain original order
+});
+
+it("should handle an order collection with elements not in toBeSorted using prioritizeOrder", function () {
+    $unordered = collect(["x", "y", "z"]);
+    $order = collect(["a", "b", "c"]);
+    /** @var \Illuminate\Support\Collection $ret */
+    $ret = SailonlagoonCommand::prioritizeOrder($order, $unordered);
+
+    expect($ret->all())->toEqual(["x", "y", "z"]); // Since none match, order stays the same
+});
+
+it("should properly handle duplicate values in toBeSorted using prioritizeOrder", function () {
+    $unordered = collect(["c", "a", "b", "a", "c", "b"]);
+    $order = collect(["a", "b", "c"]);
+    /** @var \Illuminate\Support\Collection $ret */
+    $ret = SailonlagoonCommand::prioritizeOrder($order, $unordered);
+
+    expect($ret->all())->toEqual(["a", "a", "b", "b", "c", "c"]);
+});
+
+
+it("should return the same list if toBeSorted is already ordered correctly using prioritizeOrder", function () {
+    $unordered = collect(["a", "b", "c", "x", "y", "z"]);
+    $order = collect(["a", "b", "c"]);
+    /** @var \Illuminate\Support\Collection $ret */
+    $ret = SailonlagoonCommand::prioritizeOrder($order, $unordered);
+
+    expect($ret->all())->toEqual(["a", "b", "c", "x", "y", "z"]);
+});
+


### PR DESCRIPTION
This PR introduces a way of ordering services if they're selected - it turns out that lagoon requires docker compose services to be defined in a particular order, this allows us to control that.

closes #10 